### PR TITLE
Bug DCOS-11027: Increases timeout on mnesia recovery

### DIFF
--- a/src/lashup_kv.erl
+++ b/src/lashup_kv.erl
@@ -230,7 +230,7 @@ init_db(Nodes) ->
   Tables = [kv],
   TablesToCreate = Tables -- ExistingTables,
   lists:foreach(fun create_table/1, TablesToCreate),
-  ok = mnesia:wait_for_tables(Tables, 5000).
+  ok = mnesia:wait_for_tables(Tables, 60000).
 
 create_table(kv) ->
   {atomic, ok} =  mnesia:create_table(kv, [


### PR DESCRIPTION
Mnesia didn't recover within 5 secs timeout in 1k node cluster
due to which minuteman and navstar failed to restart.
This patch fixes this issue by increasing the timeout to
60 secs.