### PR TITLE
bump the object size

### DIFF
--- a/src/lashup_kv.erl
+++ b/src/lashup_kv.erl
@@ -41,8 +41,8 @@
 -define(SERVER, ?MODULE).
 -define(INIT_LCLOCK, -1).
 
--define(WARN_OBJECT_SIZE_KB, 250).
--define(REJECT_OBJECT_SIZE_KB, 1000).
+-define(WARN_OBJECT_SIZE_MB, 60).
+-define(REJECT_OBJECT_SIZE_MB, 100).
 
 -record(state, {
   mc_ref = erlang:error() :: reference()
@@ -351,12 +351,12 @@ handle_op(Key, Op, OldVClock, State) ->
 -spec(check_map(kv()) -> {error, Reason :: term()} | ok).
 check_map(NewKV = #kv2{key = Key}) ->
   case erlang:external_size(NewKV) of
-    Size when Size > ?REJECT_OBJECT_SIZE_KB * 10000 ->
+    Size when Size > ?REJECT_OBJECT_SIZE_MB * 1000000 ->
       {error, value_too_large};
-    Size when Size > (?WARN_OBJECT_SIZE_KB + ?REJECT_OBJECT_SIZE_KB) / 2 * 10000 ->
+    Size when Size > (?WARN_OBJECT_SIZE_MB + ?REJECT_OBJECT_SIZE_MB) / 2 * 1000000 ->
       lager:warning("WARNING: Object '~p' is growing too large at ~p bytes (REJECTION IMMINENT)", [Key, Size]),
       ok;
-    Size when Size > ?WARN_OBJECT_SIZE_KB * 10000 ->
+    Size when Size > ?WARN_OBJECT_SIZE_MB * 1000000 ->
       lager:warning("WARNING: Object '~p' is growing too large at ~p bytes", [Key, Size]),
       ok;
     _ ->

--- a/test/lashup_kv_SUITE.erl
+++ b/test/lashup_kv_SUITE.erl
@@ -86,7 +86,8 @@ fetch_keys(_Config) ->
   Key3 = [x,y,z],
   {ok, _} = lashup_kv:request_op(Key3,
     {update, [{update, {flag, riak_dt_lwwreg}, {assign, true, erlang:system_time(nano_seconds)}}]}),
-  [Key1, Key2] = lashup_kv:keys(ets:fun2ms(fun({[a, b, '_']}) -> true end)),
+  Keys = lashup_kv:keys(ets:fun2ms(fun({[a, b, '_']}) -> true end)),
+  true = lists:member(Key1, Keys) and lists:member(Key2, Keys) and not lists:member(Key3, Keys),
   ok.
 
 kv_subscribe(_Config) ->


### PR DESCRIPTION
During test on 1k node cluster, the size was seen as 26M. This commit is increasing the size check to 100M. This check is there because at certain size erlang starts failing. I am not particularly sure what is that limit.