### PR TITLE
Drop labels from kv_message_queue_overflows_total metric

### DIFF
--- a/src/lashup_kv.erl
+++ b/src/lashup_kv.erl
@@ -613,7 +613,6 @@ init_op_metrics() ->
   prometheus_counter:new([
     {registry, lashup},
     {name, kv_message_queue_overflows_total},
-    {labels, [type]},
     {help, "Total number of messages dropped due to queue overflows."}
   ]).
 


### PR DESCRIPTION
Updates to this metrics which occur only under heavy load, lead to crashes of `lashup_kv` thus rendering it unable to shed load.

JIRA issue: [DCOS_OSS-5634](https://jira.mesosphere.com/browse/DCOS_OSS-5634)